### PR TITLE
Fix Nazara .so not being detected on linux

### DIFF
--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -294,7 +294,7 @@ workspace("Burgwar")
 					libdirs(dir .. "/x64")
 			end
 
-			for _, dir in pairs(frameworkLibs) do
+			for _, dir in pairs(frameworkBins) do
 				filter {"architecture:x86", "configurations:Debug"}
 					libdirs(dir .. "/debug")
 					libdirs(dir .. "/x86/debug")


### PR DESCRIPTION
All .so are in `<packageFolder>/bin/<arch> ` on linux

The loop was executed for `frameworkLibs` two times.